### PR TITLE
fix: Remove engine from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,6 @@
 	"scripts": {
 		"start": "node server.js"
 	},
-	"engines": {
-		"node": "8.11.2"
-	},
 	"repository": {
 		"type": "git",
 		"url": "https://idontknow/todo.git"


### PR DESCRIPTION
Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>

Removes the `engine` field from the `package.json` per http://github.com/freeCodeCamp/freeCodeCamp/issues/40365