### PR TITLE
Add default listen port for local server

### DIFF
--- a/server.js
+++ b/server.js
@@ -55,6 +55,6 @@ app.use(function(err, req, res, next) {
 
 //Listen on port set in environment variable or default to 3000
 const listener = app.listen(process.env.PORT || 3000, function () {
-  console.log("Node.js listening on port" + listener.address().port);
+  console.log("Node.js listening on port " + listener.address().port);
 });
 

--- a/server.js
+++ b/server.js
@@ -53,8 +53,8 @@ app.use(function(err, req, res, next) {
   }  
 })
 
-var port = process.env.PORT || 3000;
-app.listen(port, function () {
-  console.log(`Node.js listening on port ${port}...`);
+//Listen on port set in environment variable or default to 3000
+const listener = app.listen(process.env.PORT || 3000, function () {
+  console.log("Node.js listening on port" + listener.address().port);
 });
 

--- a/server.js
+++ b/server.js
@@ -53,7 +53,8 @@ app.use(function(err, req, res, next) {
   }  
 })
 
-app.listen(process.env.PORT, function () {
-  console.log('Node.js listening ...');
+var port = process.env.PORT || 3000;
+app.listen(port, function () {
+  console.log(`Node.js listening on port ${port}...`);
 });
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

I noticed the second boilerplate includes port 3000 as a default for Node to listen on when running locally.  This would've been super helpful on the initial setup, but it was a great exercise in debugging I suppose :).  Having things a little smoother out of the gates would ease frustration I'm sure.
